### PR TITLE
Update rust.yml & README.md

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build_macos_arm64:
     name: Build .app on macOS (ARM64)
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
       - name: Cache Rust dependencies

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build_macos_arm64:
     name: Build .app on macOS (ARM64)
-    runs-on: macos-13
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - name: Cache Rust dependencies

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,29 +7,8 @@ on:
     branches: [ master ]
 
 jobs:
-  build_macos_arm64:
-    name: Build .app on macOS (ARM64)
-    runs-on: macos-15
-    steps:
-      - uses: actions/checkout@v4
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2.8.0
-      - name: Install cargo-bundle
-        run: cargo install cargo-bundle
-      - name: Build .app bundle
-        run: cargo bundle --release --bin auto_morph
-      - name: Zip the .app bundle
-        run: |
-          cd target/release/bundle/osx
-          zip -r ${{ github.workspace }}/auto_morph.zip ./auto_morph.app
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: auto_morph-macos-aarch64
-          path: auto_morph.zip
-
-  build_macos_intel:
-    name: Build .app on macOS (Intel)
+  build_macos:
+    name: Build .app on macOS
     runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
@@ -46,7 +25,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: auto_morph-macos-intel
+          name: auto_morph-macos
           path: auto_morph.zip
 
   build_windows:

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
    ```
 
 4. **Run the application**
+   You may need to install Rosetta if you're running this on silicon and it isn't already installed
    ```sh
    open -a auto_morph.app
    ```

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@
 ## 🏃 Run Using Prebuilt Release Binary (macOS)
 
 1. **Download the release**  
-   Head over to the [Releases](../../releases) page and download the file corresponding to your macOS architecture:  
-   `auto_morph-macos-aarch64.zip or auto_morph-macos-intel.zip`
+   Head over to the [Releases](../../releases) page and download the zip containing the .app:  
+   `auto_morph-macos.zip`
 
 2. **Extract the archive**  
    You can extract it using Finder or via the terminal:
    ```sh
-   unzip auto_morph-macos-xxxxxx.zip
+   unzip auto_morph-macos.zip
    ```
 
 3. **Give execute permission (if needed)**  


### PR DESCRIPTION
- only one macOS version needs to be released because of Apple Rosetta. also saves up processing power by only having to do two builds per release instead of 3
- README.md was out of date